### PR TITLE
Add training loop and decode test output

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,17 @@
 
 ## Overview
 
-Concept Modelling implements a modular pipeline for streaming language processing without sequence limits. It encodes byte streams, segments concepts, quantizes representations, retrieves from an external store, and denoises with latent reasoning.
+Concept Modelling provides a modular pipeline for byte-level language processing. It encodes streams, segments spans, quantizes embeddings, retrieves related concepts, and denoises representations.
 
 ## Modules
 
-- `lcm.encoder.StreamingEncoder` processes byte sequences with a recurrent backbone.
-- `lcm.segmenter.Segmenter` infers span boundaries and pools segment features.
-- `lcm.rvq.ResidualVectorQuantizer` compresses embeddings using residual vector quantization.
-- `lcm.store.ConceptStore` persists concept vectors with approximate nearest neighbor search.
-- `lcm.denoiser.ConceptDenoiser` refines local and retrieved representations through attention-based latent updates.
-- `lcm.inference.StreamingInference` coordinates the full pipeline for online processing.
+- `lcm.encoder.StreamingEncoder`
+- `lcm.segmenter.Segmenter`
+- `lcm.rvq.ResidualVectorQuantizer`
+- `lcm.store.ConceptStore`
+- `lcm.denoiser.ConceptDenoiser`
+- `lcm.inference.StreamingInference`
+- `lcm.training`
 
 ## Usage
 
@@ -21,6 +22,16 @@ pipeline = StreamingInference()
 segments, metadata = pipeline.process(b"example text")
 ```
 
+## Training
+
+```python
+from lcm.training import train
+train("corpus.txt", epochs=1)
+```
+
 ## Testing
 
-`pytest` runs the pipeline sanity check.
+```bash
+pytest -q
+```
+The test prints segments, metadata, and decoded text.

--- a/lcm/store.py
+++ b/lcm/store.py
@@ -1,19 +1,28 @@
-import faiss
 import numpy as np
 from typing import Any
 
 class ConceptStore:
     def __init__(self, dim: int):
-        self.index = faiss.IndexFlatL2(dim)
+        self.vectors = np.empty((0, dim), dtype=np.float32)
         self.meta: list[dict[str, Any]] = []
 
     def insert(self, vectors: np.ndarray, metas: list[dict[str, Any]]) -> None:
         vectors = np.asarray(vectors, dtype=np.float32)
-        self.index.add(vectors)
+        if self.vectors.size:
+            self.vectors = np.vstack([self.vectors, vectors])
+        else:
+            self.vectors = vectors
         self.meta.extend(metas)
 
     def lookup(self, query: np.ndarray, k: int) -> tuple[np.ndarray, np.ndarray, list[list[dict[str, Any]]]]:
         query = np.asarray(query, dtype=np.float32)
-        distances, indices = self.index.search(query, k)
+        if not self.vectors.size:
+            distances = np.full((query.shape[0], k), np.inf, dtype=np.float32)
+            indices = np.full((query.shape[0], k), -1, dtype=int)
+            retrieved = [[{} for _ in range(k)] for _ in range(query.shape[0])]
+            return distances, indices, retrieved
+        dists = ((self.vectors[None, :, :] - query[:, None, :]) ** 2).sum(axis=2)
+        indices = np.argsort(dists, axis=1)[:, :k]
+        distances = np.take_along_axis(dists, indices, axis=1)
         retrieved = [[self.meta[i] for i in idx] for idx in indices]
         return distances, indices, retrieved

--- a/lcm/training.py
+++ b/lcm/training.py
@@ -1,0 +1,46 @@
+import torch
+from pathlib import Path
+from torch.utils.data import Dataset, DataLoader
+from .encoder import StreamingEncoder
+from .segmenter import Segmenter
+from .rvq import ResidualVectorQuantizer
+
+class CorpusDataset(Dataset):
+    def __init__(self, path: str, seq_len: int = 128):
+        self.data = Path(path).read_bytes()
+        self.seq_len = seq_len
+    def __len__(self) -> int:
+        return max(len(self.data) - self.seq_len, 0)
+    def __getitem__(self, idx: int) -> torch.Tensor:
+        chunk = self.data[idx:idx + self.seq_len]
+        return torch.tensor(list(chunk), dtype=torch.long)
+
+def build_models() -> tuple[StreamingEncoder, Segmenter, ResidualVectorQuantizer]:
+    encoder = StreamingEncoder()
+    segmenter = Segmenter()
+    rvq = ResidualVectorQuantizer(1024, 512, 2)
+    return encoder, segmenter, rvq
+
+def train(corpus_path: str, epochs: int = 1, batch_size: int = 32, seq_len: int = 128) -> None:
+    dataset = CorpusDataset(corpus_path, seq_len)
+    loader = DataLoader(dataset, batch_size=batch_size, shuffle=True)
+    encoder, segmenter, rvq = build_models()
+    params = list(encoder.parameters()) + list(segmenter.parameters()) + list(rvq.parameters())
+    optimizer = torch.optim.Adam(params)
+    for _ in range(epochs):
+        for batch in loader:
+            features, _ = encoder(batch)
+            loss = torch.tensor(0.0)
+            for i in range(batch.size(0)):
+                segs = segmenter.segment(features[i])
+                pooled = [segmenter.pool(features[i], s, e) for s, e in segs]
+                if not pooled:
+                    continue
+                pooled_tensor = torch.stack(pooled)
+                quant, _ = rvq(pooled_tensor)
+                loss = loss + torch.nn.functional.mse_loss(quant, pooled_tensor)
+            if loss.item() == 0.0:
+                continue
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,4 +6,4 @@ build-backend = "setuptools.build_meta"
 name = "concept-modelling"
 version = "0.1.0"
 requires-python = ">=3.12"
-dependencies = ["torch", "faiss-cpu", "numpy"]
+dependencies = ["torch", "numpy"]

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,14 +1,19 @@
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 from lcm.inference import StreamingInference
 
-def test_process_runs():
+def decode_segments(data: bytes, segments: list[tuple[int, int]]) -> list[str]:
+    return [data[s:e].decode('utf-8', errors='ignore') for s, e in segments]
+
+def test_process_runs() -> None:
     pipeline = StreamingInference()
     data = b"hello world"
     segments, metas = pipeline.process(data)
+    decoded = decode_segments(data, segments)
     assert isinstance(segments, list)
     assert len(segments) == len(metas)
+    assert len(decoded) == len(segments)
     print("Segments:", segments)
     print("Metas:", metas)
-
-if __name__ == "__main__":
-    test_process_runs()
-    print("Test passed.")
+    print("Decoded:", decoded)


### PR DESCRIPTION
## Summary
- Decode pipeline output into text during tests
- Add modular training loop using `corpus.txt`
- Replace Faiss store with pure NumPy implementation and document usage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68abb93f9f3c8321a76c205a5f7b2f60