### PR TITLE
Add concept planner and byte decoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Concept Modelling provides a modular pipeline for byte-level language processing. It encodes streams, segments spans, quantizes embeddings, retrieves related concepts, and denoises representations.
+Concept Modelling provides a modular pipeline for byte-level language processing. It encodes streams, segments spans, quantizes embeddings, retrieves related concepts, plans responses, and realizes byte outputs.
 
 ## Modules
 
@@ -10,9 +10,11 @@ Concept Modelling provides a modular pipeline for byte-level language processing
 - `lcm.segmenter.Segmenter`
 - `lcm.rvq.ResidualVectorQuantizer`
 - `lcm.store.ConceptStore`
-- `lcm.denoiser.ConceptDenoiser`
 - `lcm.inference.StreamingInference`
 - `lcm.training`
+- `lcm.planner.ConceptPlanner`
+- `lcm.realizer.ByteDiffusionDecoder`
+- `lcm.realizer.SegmentCTCRealizer`
 
 ## Setup
 
@@ -25,7 +27,7 @@ pip install -r requirements.txt
 ```python
 from lcm.inference import StreamingInference
 pipeline = StreamingInference()
-segments, metadata = pipeline.process(b"example text")
+segments, metadata, output = pipeline.process(b"example text")
 ```
 
 ## Training
@@ -40,4 +42,4 @@ train("corpus.txt", epochs=1)
 ```bash
 pytest -q
 ```
-The test prints segments, metadata, and decoded text.
+The test prints segments, metadata, decoded text, and output length.

--- a/lcm/planner.py
+++ b/lcm/planner.py
@@ -1,0 +1,22 @@
+import torch
+import torch.nn as nn
+
+class ConceptPlanner(nn.Module):
+    def __init__(self, latent_dim: int = 512, latent_len: int = 128, heads: int = 8):
+        super().__init__()
+        self.latent_dim = latent_dim
+        self.latent_len = latent_len
+        self.self_attn = nn.MultiheadAttention(latent_dim, heads, batch_first=True)
+        self.cross_local = nn.MultiheadAttention(latent_dim, heads, batch_first=True)
+        self.cross_retrieved = nn.MultiheadAttention(latent_dim, heads, batch_first=True)
+        self.linear = nn.Linear(latent_dim, latent_dim)
+    def forward(self, local: torch.Tensor, retrieved: torch.Tensor | None, steps: int) -> torch.Tensor:
+        batch = local.size(0)
+        z = torch.randn(batch, self.latent_len, self.latent_dim, device=local.device)
+        for _ in range(steps):
+            z, _ = self.self_attn(z, z, z)
+            z, _ = self.cross_local(z, local, local)
+            if retrieved is not None:
+                z, _ = self.cross_retrieved(z, retrieved, retrieved)
+            z = self.linear(z)
+        return z

--- a/lcm/realizer.py
+++ b/lcm/realizer.py
@@ -1,0 +1,35 @@
+import torch
+import torch.nn as nn
+
+class ByteDiffusionDecoder(nn.Module):
+    def __init__(self, latent_dim: int = 512, steps: int = 2):
+        super().__init__()
+        self.steps = steps
+        self.layers = nn.ModuleList([nn.Linear(latent_dim, latent_dim) for _ in range(steps)])
+        self.head = nn.Linear(latent_dim, 256)
+    def forward(self, plan: torch.Tensor) -> torch.Tensor:
+        x = plan
+        for layer in self.layers:
+            x = layer(x)
+        logits = self.head(x)
+        return logits
+    def sample(self, plan: torch.Tensor) -> bytes:
+        logits = self.forward(plan)
+        bytes_tensor = logits.argmax(dim=-1).to(torch.uint8)
+        return bytes_tensor.flatten().cpu().numpy().tobytes()
+
+class SegmentCTCRealizer(nn.Module):
+    def __init__(self, latent_dim: int = 512, max_len: int = 16):
+        super().__init__()
+        self.latent_dim = latent_dim
+        self.max_len = max_len
+        self.length_predictor = nn.Linear(latent_dim, 1)
+        self.classifier = nn.Linear(latent_dim, 256)
+    def decode(self, plan: torch.Tensor) -> bytes:
+        lengths = self.length_predictor(plan).relu().floor().clamp(min=1, max=self.max_len).long()
+        logits = self.classifier(plan)
+        codes = logits.argmax(dim=-1).to(torch.uint8)
+        output = []
+        for i in range(plan.size(1)):
+            output.extend([codes[0, i].item()] * lengths[0, i].item())
+        return bytes(output)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -9,11 +9,14 @@ def decode_segments(data: bytes, segments: list[tuple[int, int]]) -> list[str]:
 def test_process_runs() -> None:
     pipeline = StreamingInference()
     data = b"hello world"
-    segments, metas = pipeline.process(data)
+    segments, metas, output = pipeline.process(data)
     decoded = decode_segments(data, segments)
     assert isinstance(segments, list)
+    assert isinstance(output, bytes)
+    assert len(output) > 0
     assert len(segments) == len(metas)
     assert len(decoded) == len(segments)
     print("Segments:", segments)
     print("Metas:", metas)
     print("Decoded:", decoded)
+    print("Output bytes length:", len(output))


### PR DESCRIPTION
## Summary
- introduce non-autoregressive ConceptPlanner to build latent concept plans
- add ByteDiffusionDecoder and SegmentCTCRealizer for byte-level realization
- integrate planning and realization into StreamingInference and update tests and docs

## Testing
- `pytest -q`