### PR TITLE
Add model serialization and chat interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,14 @@ segments, metadata, output = pipeline.process(b"example text")
 
 ```python
 from lcm.training import train
-train("corpus.txt", epochs=1)
+train("corpus.txt", epochs=1, model_dir="models")
+```
+
+## Chat
+
+```python
+from lcm.chat import chat
+chat("models")
 ```
 
 ## Testing

--- a/lcm/chat.py
+++ b/lcm/chat.py
@@ -1,0 +1,27 @@
+import torch
+from .inference import StreamingInference
+from .io import load_models
+from .utils import get_device
+
+
+def build_pipeline(path: str, device: torch.device | None = None) -> StreamingInference:
+    device = device or get_device()
+    pipeline = StreamingInference(device=device)
+    encoder, segmenter, rvq = load_models(path, device)
+    pipeline.encoder = encoder
+    pipeline.segmenter = segmenter
+    pipeline.rvq = rvq
+    return pipeline
+
+
+def chat(path: str) -> None:
+    pipeline = build_pipeline(path)
+    while True:
+        try:
+            line = input(" > ")
+        except (EOFError, KeyboardInterrupt):
+            break
+        if not line:
+            continue
+        _, _, out = pipeline.process(line.encode())
+        print(out.decode(errors="ignore"))

--- a/lcm/io.py
+++ b/lcm/io.py
@@ -1,0 +1,26 @@
+import torch
+from pathlib import Path
+from .encoder import StreamingEncoder
+from .segmenter import Segmenter
+from .rvq import ResidualVectorQuantizer
+from .utils import get_device
+
+
+def save_models(path: str, encoder: StreamingEncoder, segmenter: Segmenter, rvq: ResidualVectorQuantizer) -> None:
+    p = Path(path)
+    p.mkdir(parents=True, exist_ok=True)
+    torch.save(encoder.state_dict(), p / "encoder.pt")
+    torch.save(segmenter.state_dict(), p / "segmenter.pt")
+    torch.save(rvq.state_dict(), p / "rvq.pt")
+
+
+def load_models(path: str, device: torch.device | None = None) -> tuple[StreamingEncoder, Segmenter, ResidualVectorQuantizer]:
+    device = device or get_device()
+    encoder = StreamingEncoder().to(device)
+    segmenter = Segmenter().to(device)
+    rvq = ResidualVectorQuantizer(1024, 512, 2).to(device)
+    p = Path(path)
+    encoder.load_state_dict(torch.load(p / "encoder.pt", map_location=device))
+    segmenter.load_state_dict(torch.load(p / "segmenter.pt", map_location=device))
+    rvq.load_state_dict(torch.load(p / "rvq.pt", map_location=device))
+    return encoder, segmenter, rvq

--- a/lcm/training.py
+++ b/lcm/training.py
@@ -5,6 +5,7 @@ from .encoder import StreamingEncoder
 from .segmenter import Segmenter
 from .rvq import ResidualVectorQuantizer
 from .utils import get_device
+from .io import save_models
 
 class CorpusDataset(Dataset):
     def __init__(self, path: str, seq_len: int = 128):
@@ -22,7 +23,7 @@ def build_models(device: torch.device) -> tuple[StreamingEncoder, Segmenter, Res
     rvq = ResidualVectorQuantizer(1024, 512, 2).to(device)
     return encoder, segmenter, rvq
 
-def train(corpus_path: str, epochs: int = 1, batch_size: int = 32, seq_len: int = 128) -> None:
+def train(corpus_path: str, epochs: int = 1, batch_size: int = 32, seq_len: int = 128, model_dir: str | None = None) -> None:
     device = get_device()
     dataset = CorpusDataset(corpus_path, seq_len)
     loader = DataLoader(dataset, batch_size=batch_size, shuffle=True)
@@ -47,3 +48,5 @@ def train(corpus_path: str, epochs: int = 1, batch_size: int = 32, seq_len: int 
             optimizer.zero_grad()
             loss.backward()
             optimizer.step()
+    if model_dir is not None:
+        save_models(model_dir, encoder, segmenter, rvq)


### PR DESCRIPTION
## Summary
- Save encoder, segmenter, and RVQ weights after training
- Provide utilities to persist and load model components
- Enable interactive chatting with trained models

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68abc0d5ad788321ad1dee61c7ea3ea3